### PR TITLE
Searcher & sorter (+ some modifications)

### DIFF
--- a/lib/json_api_filter.rb
+++ b/lib/json_api_filter.rb
@@ -7,6 +7,7 @@ require "json_api_filter/field_filters/matcher"
 require "json_api_filter/field_filters/compare"
 require "json_api_filter/field_filters/searcher"
 require "json_api_filter/field_filters/sorter"
+require "json_api_filter/field_filters/pagination"
 require "active_support/concern"
 require "active_support/core_ext/object/blank"
 

--- a/lib/json_api_filter.rb
+++ b/lib/json_api_filter.rb
@@ -5,6 +5,8 @@ require "json_api_filter/value_parser"
 require "json_api_filter/field_filters/base"
 require "json_api_filter/field_filters/matcher"
 require "json_api_filter/field_filters/compare"
+require "json_api_filter/field_filters/searcher"
+require "json_api_filter/field_filters/sorter"
 require "active_support/concern"
 require "active_support/core_ext/object/blank"
 
@@ -27,7 +29,8 @@ module JsonApiFilter
       ::JsonApiFilter::Dispatch.new(
         scope,
         query_params,
-        allowed_filters: self.class.json_api_permitted_filters
+        allowed_filters: self.class.json_api_permitted_filters,
+        allowed_searches: self.class.json_api_permitted_searches
       ).process
     end
 
@@ -39,6 +42,16 @@ module JsonApiFilter
 
     def self.json_api_permitted_filters
       []
+    end
+
+    def self.permitted_searches(global, **columns)
+      define_singleton_method(:json_api_permitted_searches) do
+        { global: global, columns: columns }
+      end
+    end
+
+    def self.json_api_permitted_searches
+      {}
     end
   end
 end

--- a/lib/json_api_filter/dispatch.rb
+++ b/lib/json_api_filter/dispatch.rb
@@ -20,6 +20,7 @@ module JsonApiFilter
         sort_predicate,
         filters_predicate,
         search_predicate,
+        pagination_predicate
       ].compact.reduce(&:merge)
     end
     
@@ -56,6 +57,15 @@ module JsonApiFilter
       ::JsonApiFilter::FieldFilters::Searcher.new(
         scope,
         {allowed_searches[:global] => parser_params[:search]}
+      ).predicate
+    end
+
+    # @return [ActiveRecord::Base, NilClass]
+    def pagination_predicate
+      return nil if parser_params[:pagination].nil?
+      ::JsonApiFilter::FieldFilters::Pagination.new(
+        scope,
+        parser_params[:pagination]
       ).predicate
     end
     

--- a/lib/json_api_filter/field_filters/compare.rb
+++ b/lib/json_api_filter/field_filters/compare.rb
@@ -2,14 +2,31 @@
 module JsonApiFilter
   module FieldFilters
     class Compare < Base
+
+      attr_reader :allowed_searches
+
+      def initialize(scope, values, allowed_searches:)
+        super(scope, values)
+        @allowed_searches = allowed_searches
+      end
   
       # @return [ActiveRecord_Relation]
       def predicate
         column = values.keys.first
         filter = values.first[1]
         filter.map do |key, value|
-          compare(column, key, value)
-        end.reduce(&:merge)
+          if !WHERE_METHODS[key.to_sym].nil?
+            self.class.compare(scope, column, key, value)
+          elsif key == "search"
+            next unless allowed_searches[:columns].keys.include?(column.to_sym)
+            ::JsonApiFilter::FieldFilters::Searcher.new(
+              scope,
+              {allowed_searches[:columns][column.to_sym] => value}
+            ).predicate
+          else
+            nil
+          end
+        end.compact.reduce(&:merge)
       end
       
       private
@@ -23,12 +40,16 @@ module JsonApiFilter
         le: "<=",
       }
       
-      def compare(column, method, value)
+      def self.compare(scope, column, method, value)
         # convert enums to their integer representation
         unless scope.defined_enums[column].nil?
           value = scope.defined_enums[column][value]
         end
-        scope.where("#{column} #{WHERE_METHODS[method.to_sym]} ?", value)
+        if WHERE_METHODS[method.to_sym] == "=" && value.class == Array
+          scope.where(column => value)
+        else
+          scope.where("#{column} #{WHERE_METHODS[method.to_sym]} ?", value)
+        end
       end
     
     end

--- a/lib/json_api_filter/field_filters/compare.rb
+++ b/lib/json_api_filter/field_filters/compare.rb
@@ -16,7 +16,7 @@ module JsonApiFilter
         filter = values.first[1]
         filter.map do |key, value|
           if !WHERE_METHODS[key.to_sym].nil?
-            self.class.compare(scope, column, key, value)
+            compare(column, key, value)
           elsif key == "search"
             next unless allowed_searches[:columns].keys.include?(column.to_sym)
             ::JsonApiFilter::FieldFilters::Searcher.new(
@@ -40,12 +40,9 @@ module JsonApiFilter
         le: "<=",
       }
       
-      def self.compare(scope, column, method, value)
-        # convert enums to their integer representation
-        unless scope.defined_enums[column].nil?
-          value = scope.defined_enums[column][value]
-        end
-        if WHERE_METHODS[method.to_sym] == "=" && value.class == Array
+      def compare(column, method, value)
+        if WHERE_METHODS[method.to_sym] == "="
+          # prefer this method for eq as it implicitely transforms enum into their integer representation
           scope.where(column => value)
         else
           scope.where("#{column} #{WHERE_METHODS[method.to_sym]} ?", value)

--- a/lib/json_api_filter/field_filters/matcher.rb
+++ b/lib/json_api_filter/field_filters/matcher.rb
@@ -5,7 +5,7 @@ module JsonApiFilter
       # @return [ActiveRecord_Relation]
       def predicate
         values.map do |key, value|
-          ::JsonApiFilter::FieldFilters::Compare.compare(scope, key, :eq, ::JsonApiFilter::ValueParser.parse(value))
+          scope.where(key => ::JsonApiFilter::ValueParser.parse(value))
         end.reduce(&:merge)
       end
     

--- a/lib/json_api_filter/field_filters/matcher.rb
+++ b/lib/json_api_filter/field_filters/matcher.rb
@@ -5,7 +5,7 @@ module JsonApiFilter
       # @return [ActiveRecord_Relation]
       def predicate
         values.map do |key, value|
-          scope.where(key => ::JsonApiFilter::ValueParser.parse(value))
+          ::JsonApiFilter::FieldFilters::Compare.compare(scope, key, :eq, ::JsonApiFilter::ValueParser.parse(value))
         end.reduce(&:merge)
       end
     

--- a/lib/json_api_filter/field_filters/pagination.rb
+++ b/lib/json_api_filter/field_filters/pagination.rb
@@ -7,9 +7,9 @@ module JsonApiFilter
         page = values["page"]
         per_page = values["perPage"]
         result = scope
-        unless page.nil? || per_page.nil? || per_page == -1
-          result = result.limit(per_page)
-          result = result.offset((page - 1) * per_page)
+        unless page.nil? || per_page.nil? || per_page == "-1"
+          result = result.limit(per_page.to_i)
+          result = result.offset((page.to_i - 1) * per_page.to_i)
         end
         result
       end

--- a/lib/json_api_filter/field_filters/pagination.rb
+++ b/lib/json_api_filter/field_filters/pagination.rb
@@ -1,0 +1,19 @@
+module JsonApiFilter
+  module FieldFilters
+    class Pagination < Base
+  
+      # @return [ActiveRecord_Relation]
+      def predicate
+        page = values["page"]
+        per_page = values["perPage"]
+        result = scope
+        unless page.nil? || per_page.nil? || per_page == -1
+          result = result.limit(per_page)
+          result = result.offset((page - 1) * per_page)
+        end
+        result
+      end
+
+    end
+  end
+end

--- a/lib/json_api_filter/field_filters/searcher.rb
+++ b/lib/json_api_filter/field_filters/searcher.rb
@@ -1,0 +1,12 @@
+module JsonApiFilter
+  module FieldFilters
+    class Searcher < Base
+  
+      # @return [ActiveRecord_Relation]
+      def predicate
+        scope.send(values.keys.first, values.values.first)
+      end
+
+    end
+  end
+end

--- a/lib/json_api_filter/field_filters/sorter.rb
+++ b/lib/json_api_filter/field_filters/sorter.rb
@@ -5,10 +5,13 @@ module JsonApiFilter
       # @return [ActiveRecord_Relation]
       def predicate
         return nil if values["by"].nil?
-        result = scope
-        result = result.order(values["by"])
-        result = result.reverse_order if values["desc"] == "true"
-        result
+        scope.order(values["by"] => order)
+      end
+
+      private
+
+      def order
+        ActiveModel::Type::Boolean.new.cast(values["desc"]) ? :desc : :asc
       end
     
     end

--- a/lib/json_api_filter/field_filters/sorter.rb
+++ b/lib/json_api_filter/field_filters/sorter.rb
@@ -1,0 +1,16 @@
+module JsonApiFilter
+  module FieldFilters
+    class Sorter < Base
+  
+      # @return [ActiveRecord_Relation]
+      def predicate
+        return nil if values["by"].nil?
+        result = scope
+        result = result.order(values["by"])
+        result = result.reverse_order if values["desc"] == true
+        result
+      end
+    
+    end
+  end
+end

--- a/lib/json_api_filter/field_filters/sorter.rb
+++ b/lib/json_api_filter/field_filters/sorter.rb
@@ -7,7 +7,7 @@ module JsonApiFilter
         return nil if values["by"].nil?
         result = scope
         result = result.order(values["by"])
-        result = result.reverse_order if values["desc"] == true
+        result = result.reverse_order if values["desc"] == "true"
         result
       end
     

--- a/lib/json_api_filter/value_parser.rb
+++ b/lib/json_api_filter/value_parser.rb
@@ -13,7 +13,7 @@ module JsonApiFilter
     end
     
     def parse
-      return value unless value.include?(",")
+      return [value] unless value.include?(",")
       value.split(',')
     end
   

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.2-x86_64-linux)
+      racc (~> 1.4)
     puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -132,6 +134,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   byebug

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,2 +1,11 @@
 class User < ApplicationRecord
+
+  def self.fake_global_search(value)
+    where("name = ?", value)
+  end
+  
+  def self.fake_name_search(value)
+    where("name = ?", value)
+  end
+
 end

--- a/spec/json_api_filter_spec.rb
+++ b/spec/json_api_filter_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe JsonApiFilter do
                 by: "id"
               }
             },
-            request: User.order("id")
+            request: User.order(:id)
           },
           {
             name: "sort by descending id",
@@ -152,7 +152,7 @@ RSpec.describe JsonApiFilter do
                 desc: true
               }
             },
-            request: User.order("id").reverse_order
+            request: User.order(id: :desc)
           },
           {
             name: "sort by name",
@@ -161,7 +161,7 @@ RSpec.describe JsonApiFilter do
                 by: "name"
               }
             },
-            request: User.order("name")
+            request: User.order(:name)
           },
         ]
       },

--- a/spec/json_api_filter_spec.rb
+++ b/spec/json_api_filter_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe JsonApiFilter do
             params: {
               filter: { id: {eq: 1} }
             },
-            request: User.where("id = 1")
+            request: User.where("id" => "1")
           },
           {
             name: 'not eq id',
@@ -105,7 +105,7 @@ RSpec.describe JsonApiFilter do
                 name: {eq: "foo"}
               }
             },
-            request: User.where("id <= 1").where("name = 'foo'")
+            request: User.where("id <= 1").where("name" => "foo")
           }
        ]
       },

--- a/spec/json_api_filter_spec.rb
+++ b/spec/json_api_filter_spec.rb
@@ -3,7 +3,9 @@ RSpec.describe JsonApiFilter do
   before do
     class FakesController
       include ::JsonApiFilter
-      permitted_filters  %i[id author]
+      permitted_filters  %i[id author name]
+      permitted_searches :fake_global_search,
+                         name: :fake_name_search
     end
   end
   after { Object.send :remove_const, :FakesController }
@@ -106,6 +108,62 @@ RSpec.describe JsonApiFilter do
             request: User.where("id <= 1").where("name = 'foo'")
           }
        ]
+      },
+      {
+        name: "JsonApiFilter::FieldFilters::Searcher",
+        examples: [
+          {
+            name: "global search",
+            params: {
+              search: "test user"
+            },
+            request: User.where("name = 'test user'")
+          },
+          {
+            name: "column search",
+            params: {
+              filter: {
+                name: {
+                  search: "test user"
+                }
+              }
+            },
+            request: User.where("name = 'test user'")
+          }
+        ]
+      },
+      {
+        name: "JsonApiFilter::FieldFilters::Sorter",
+        examples: [
+          {
+            name: "sort by id",
+            params: {
+              sort: {
+                by: "id"
+              }
+            },
+            request: User.order("id")
+          },
+          {
+            name: "sort by descending id",
+            params: {
+              sort: {
+                by: "id",
+                desc: true
+              }
+            },
+            request: User.order("id").reverse_order
+          },
+          {
+            name: "sort by name",
+            params: {
+              sort: {
+                by: "name"
+              }
+            },
+            request: User.order("name")
+          },
+        ]
       }
     ]
 

--- a/spec/json_api_filter_spec.rb
+++ b/spec/json_api_filter_spec.rb
@@ -164,6 +164,31 @@ RSpec.describe JsonApiFilter do
             request: User.order("name")
           },
         ]
+      },
+      {
+        name: "JsonApiFilter::FieldFilters::Pagination",
+        examples: [
+          {
+            name: "first page with 10 elements",
+            params: {
+              pagination: {
+                page: 1,
+                perPage: 10
+              }
+            },
+            request: User.limit(10).offset(0)
+          },
+          {
+            name: "third page with 5 elements",
+            params: {
+              pagination: {
+                page: 3,
+                perPage: 5
+              }
+            },
+            request: User.limit(5).offset(10)
+          }
+        ]
       }
     ]
 


### PR DESCRIPTION
Added:
- Searcher field filter
- Sorter field filter
- Pagination field filter
- Tests for each new filter
- `allowed_searches` method to list permitted search methods

Changes:
- ValueParser now always return an array which makes equality wheres more consistent
- Matcher now calls Compare with the `eq` method, making all equality behavior consistent, and allowing enums to be passed and found with their string representation (separated with `,`)
- Column names are now verified before being injected in `where`, avoiding potential SQL injections from untrusted user queries