### PR TITLE
Fixes (pgsearch workaround & pagination)

### DIFF
--- a/lib/json_api_filter/dispatch.rb
+++ b/lib/json_api_filter/dispatch.rb
@@ -20,7 +20,7 @@ module JsonApiFilter
         sort_predicate,
         filters_predicate,
         search_predicate
-      ].compact.reduce(&:merge).order(:id)
+      ].compact.reduce(&:merge)
       return scope if params[:pagination].nil?
       scope.merge(pagination_predicate)
     end

--- a/lib/json_api_filter/dispatch.rb
+++ b/lib/json_api_filter/dispatch.rb
@@ -15,13 +15,14 @@ module JsonApiFilter
 
     # @return [ActiveRecord_Relation]
     def process
-      [
+      @scope = [
         scope.all,
         sort_predicate,
         filters_predicate,
-        search_predicate,
-        pagination_predicate
-      ].compact.reduce(&:merge)
+        search_predicate
+      ].compact.reduce(&:merge).order(:id)
+      return scope if params[:pagination].nil?
+      scope.merge(pagination_predicate)
     end
     
     private

--- a/lib/json_api_filter/field_filters/searcher.rb
+++ b/lib/json_api_filter/field_filters/searcher.rb
@@ -4,7 +4,7 @@ module JsonApiFilter
   
       # @return [ActiveRecord_Relation]
       def predicate
-        scope.send(values.keys.first, values.values.first)
+        scope.where(id: scope.send(values.keys.first, values.values.first).select(:id))
       end
 
     end

--- a/spec/json_api_filter_spec.rb
+++ b/spec/json_api_filter_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe JsonApiFilter do
             params: {
               search: "test user"
             },
-            request: User.where("name = 'test user'")
+            request: User.where(id: User.where("name = 'test user'").select(:id))
           },
           {
             name: "column search",
@@ -128,7 +128,7 @@ RSpec.describe JsonApiFilter do
                 }
               }
             },
-            request: User.where("name = 'test user'")
+            request: User.where(id: User.where("name = 'test user'").select(:id))
           }
         ]
       },
@@ -202,7 +202,7 @@ RSpec.describe JsonApiFilter do
         
         
         it "Filter by #{tc['name']}" do
-          expect(object.json_api_filter(User, tc['params'])).to eq(tc['request'])
+          expect(object.json_api_filter(User, tc['params'])).to eq(tc['request'].order(:id))
         end
       end
     end

--- a/spec/json_api_filter_spec.rb
+++ b/spec/json_api_filter_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe JsonApiFilter do
         
         
         it "Filter by #{tc['name']}" do
-          expect(object.json_api_filter(User, tc['params'])).to eq(tc['request'].order(:id))
+          expect(object.json_api_filter(User, tc['params'])).to eq(tc['request'])
         end
       end
     end
@@ -210,4 +210,3 @@ RSpec.describe JsonApiFilter do
   end
 
 end
-


### PR DESCRIPTION
- pgsearch caused issues when combining different searches against the same column
- pagination was broken and did not return entries in a well defined order when sorting with a column that doesn't store unique values, now every filter call is sorted by id